### PR TITLE
feat: arrow uuid matching and cosmetics core

### DIFF
--- a/data/tag/functions/load.mcfunction
+++ b/data/tag/functions/load.mcfunction
@@ -209,10 +209,10 @@ scoreboard objectives add temp_store.crossbow_glowing dummy
 scoreboard objectives add temp_store.knife dummy
 
 # arrows
-scoreboard objectives add temp_store.arrow.uuid.0 dummy
-scoreboard objectives add temp_store.arrow.uuid.1 dummy
-scoreboard objectives add temp_store.arrow.uuid.2 dummy
-scoreboard objectives add temp_store.arrow.uuid.3 dummy
+scoreboard objectives add temp_store.uuid.0 dummy
+scoreboard objectives add temp_store.uuid.1 dummy
+scoreboard objectives add temp_store.uuid.2 dummy
+scoreboard objectives add temp_store.uuid.3 dummy
 scoreboard objectives add temp_store.arrow.cosmetic_id dummy
 
 

--- a/data/tag/functions/load.mcfunction
+++ b/data/tag/functions/load.mcfunction
@@ -208,6 +208,13 @@ scoreboard objectives add temp_store.crossbow_poison dummy
 scoreboard objectives add temp_store.crossbow_glowing dummy
 scoreboard objectives add temp_store.knife dummy
 
+# arrows
+scoreboard objectives add temp_store.arrow.uuid.0 dummy
+scoreboard objectives add temp_store.arrow.uuid.1 dummy
+scoreboard objectives add temp_store.arrow.uuid.2 dummy
+scoreboard objectives add temp_store.arrow.uuid.3 dummy
+scoreboard objectives add temp_store.arrow.cosmetic_id dummy
+
 
 # health
 scoreboard objectives add health.apple minecraft.used:minecraft.apple

--- a/data/tag/functions/load.mcfunction
+++ b/data/tag/functions/load.mcfunction
@@ -216,6 +216,11 @@ scoreboard objectives add temp_store.uuid.3 dummy
 scoreboard objectives add temp_store.arrow.cosmetic_id dummy
 
 
+# cosmetics
+## arrow trail
+scoreboard objectives add cosmetic.arrow_trail dummy
+
+
 # health
 scoreboard objectives add health.apple minecraft.used:minecraft.apple
 scoreboard objectives add health.golden_apple minecraft.used:minecraft.golden_apple

--- a/data/tag/functions/main.mcfunction
+++ b/data/tag/functions/main.mcfunction
@@ -45,6 +45,8 @@ execute as @e[type=#arrows,tag=!arrow.patched] if score @s temp_store.arrow_inde
 execute as @e[type=#arrows,tag=!arrow.patched] if score @s temp_store.arrow_index = crossbow_glowing.index internal run data modify entity @s damage set value 0.2d
 scoreboard players reset @e[type=#arrows,tag=!arrow.patched] temp_store.arrow_index
 tag @e[type=#arrows,tag=!arrow.patched] add arrow.patched
+## arrow binding
+execute if entity @e[type=#arrows,tag=!arrow.has_uuid] run function tag:system/arrow/main
 
 # kill arrows
 execute as @e[type=#arrows,nbt={inGround:1b}] at @s run particle block gravel ~ ~ ~ 0 0 0 0 10

--- a/data/tag/functions/main.mcfunction
+++ b/data/tag/functions/main.mcfunction
@@ -36,6 +36,9 @@ function tag:system/lobby/main
 execute if score period internal matches 1 if score matchmaking_controller internal matches 1.. run scoreboard players set matchmaking_controller internal 0
 execute if score period internal matches 1 if score matchmaking internal matches 1.. run scoreboard players set matchmaking internal 0
 
+# player uuid (if required)
+execute if entity @e[type=#arrows,tag=!arrow.has_uuid] as @a run function tag:system/player/uuid
+
 # remove arrow piercing into player
 execute as @e[type=#arrows,tag=!arrow.patched] run data merge entity @s {PierceLevel:1b}
 execute as @e[type=#arrows,tag=!arrow.patched] store result score @s temp_store.arrow_index run data get entity @s Color

--- a/data/tag/functions/main.mcfunction
+++ b/data/tag/functions/main.mcfunction
@@ -37,7 +37,7 @@ execute if score period internal matches 1 if score matchmaking_controller inter
 execute if score period internal matches 1 if score matchmaking internal matches 1.. run scoreboard players set matchmaking internal 0
 
 # player uuid (if required)
-execute if entity @e[type=#arrows,tag=!arrow.has_uuid] as @a run function tag:system/player/uuid
+execute if entity @e[type=#arrows,tag=!arrow.has_uuid] as @a[tag=!player.has_uuid] run function tag:system/player/uuid
 
 # remove arrow piercing into player
 execute as @e[type=#arrows,tag=!arrow.patched] run data merge entity @s {PierceLevel:1b}

--- a/data/tag/functions/system/arrow/check_player.mcfunction
+++ b/data/tag/functions/system/arrow/check_player.mcfunction
@@ -4,6 +4,6 @@
 
 execute if score @s temp_store.uuid.0 = @e[tag=arrow.checking,limit=1] temp_store.uuid.0 if score @s temp_store.uuid.1 = @e[tag=arrow.checking,limit=1] temp_store.uuid.1 if score @s temp_store.uuid.2 = @e[tag=arrow.checking,limit=1] temp_store.uuid.2 if score @s temp_store.uuid.3 = @e[tag=arrow.checking,limit=1] temp_store.uuid.3 run tag @s add player.has_arrow
 
-execute if score @s cosmetic.arrow_trail matches 0.. if entity @s[tag=player.has_arrow] run scoreboard players operation @s cosmetic.arrow_trail = @e[tag=arrow.checking] cosmetic.arrow_trail
+execute if score @s cosmetic.arrow_trail matches 0.. if entity @s[tag=player.has_arrow] run scoreboard players operation @e[tag=arrow.checking] cosmetic.arrow_trail = @s cosmetic.arrow_trail
 execute if entity @s[tag=player.has_arrow] run tag @e[tag=arrow.checking] add arrow.has_uuid
 tag @e[tag=arrow.checking] remove arrow.checking

--- a/data/tag/functions/system/arrow/check_player.mcfunction
+++ b/data/tag/functions/system/arrow/check_player.mcfunction
@@ -4,6 +4,6 @@
 
 execute if score @s temp_store.uuid.0 = @e[tag=arrow.checking,limit=1] temp_store.uuid.0 if score @s temp_store.uuid.1 = @e[tag=arrow.checking,limit=1] temp_store.uuid.1 if score @s temp_store.uuid.2 = @e[tag=arrow.checking,limit=1] temp_store.uuid.2 if score @s temp_store.uuid.3 = @e[tag=arrow.checking,limit=1] temp_store.uuid.3 run tag @s add player.has_arrow
 
-execute if entity @s[tag=player.has_arrow] run scoreboard players operation @s cosmetic.arrow_trail = @e[tag=arrow.checking] cosmetic.arrow_trail
+execute if score @s cosmetic.arrow_trail matches 0.. if entity @s[tag=player.has_arrow] run scoreboard players operation @s cosmetic.arrow_trail = @e[tag=arrow.checking] cosmetic.arrow_trail
 execute if entity @s[tag=player.has_arrow] run tag @e[tag=arrow.checking] add arrow.has_uuid
 tag @e[tag=arrow.checking] remove arrow.checking

--- a/data/tag/functions/system/arrow/check_player.mcfunction
+++ b/data/tag/functions/system/arrow/check_player.mcfunction
@@ -4,6 +4,6 @@
 
 execute if score @s temp_store.uuid.0 = @e[tag=arrow.checking,limit=1] temp_store.uuid.0 if score @s temp_store.uuid.1 = @e[tag=arrow.checking,limit=1] temp_store.uuid.1 if score @s temp_store.uuid.2 = @e[tag=arrow.checking,limit=1] temp_store.uuid.2 if score @s temp_store.uuid.3 = @e[tag=arrow.checking,limit=1] temp_store.uuid.3 run tag @s add player.has_arrow
 
-execute if entity @s[tag=player.has_arrow] run scoreboard players operation @s player.cosmetic.arrow_trail = @e[tag=arrow.checking] temp_store.arrow.cosmetic.arrow_trail
+execute if entity @s[tag=player.has_arrow] run scoreboard players operation @s cosmetic.arrow_trail = @e[tag=arrow.checking] cosmetic.arrow_trail
 execute if entity @s[tag=player.has_arrow] run tag @e[tag=arrow.checking] add arrow.has_uuid
 tag @e[tag=arrow.checking] remove arrow.checking

--- a/data/tag/functions/system/arrow/check_player.mcfunction
+++ b/data/tag/functions/system/arrow/check_player.mcfunction
@@ -1,0 +1,9 @@
+# LASERTAG arrow binding
+## check player
+
+
+execute if score @s temp_store.uuid.0 = @e[tag=arrow.checking,limit=1] temp_store.uuid.0 if score @s temp_store.uuid.1 = @e[tag=arrow.checking,limit=1] temp_store.uuid.1 if score @s temp_store.uuid.2 = @e[tag=arrow.checking,limit=1] temp_store.uuid.2 if score @s temp_store.uuid.3 = @e[tag=arrow.checking,limit=1] temp_store.uuid.3 run tag @s add player.has_arrow
+
+execute if entity @s[tag=player.has_arrow] run scoreboard players operation @s player.cosmetic.arrow_trail = @e[tag=arrow.checking] temp_store.arrow.cosmetic.arrow_trail
+execute if entity @s[tag=player.has_arrow] run tag @e[tag=arrow.checking] add arrow.has_uuid
+tag @e[tag=arrow.checking] remove arrow.checking

--- a/data/tag/functions/system/arrow/main.mcfunction
+++ b/data/tag/functions/system/arrow/main.mcfunction
@@ -1,0 +1,16 @@
+# LASERTAG arrow binding
+## main loop
+
+
+tag @e[type=#arrows,tag=!arrow.has_uuid,sort=random,limit=1] add arrow.checking
+
+# get uuid
+execute store result score @s temp_store.arrow.uuid.0 run data get entity @s Owner[0]
+execute store result score @s temp_store.arrow.uuid.1 run data get entity @s Owner[1]
+execute store result score @s temp_store.arrow.uuid.2 run data get entity @s Owner[2]
+execute store result score @s temp_store.arrow.uuid.3 run data get entity @s Owner[3]
+
+
+
+
+tag @e[tag=arrow.checking] remove arrow.checking

--- a/data/tag/functions/system/arrow/main.mcfunction
+++ b/data/tag/functions/system/arrow/main.mcfunction
@@ -5,12 +5,9 @@
 tag @e[type=#arrows,tag=!arrow.has_uuid,sort=random,limit=1] add arrow.checking
 
 # get uuid
-execute store result score @s temp_store.arrow.uuid.0 run data get entity @s Owner[0]
-execute store result score @s temp_store.arrow.uuid.1 run data get entity @s Owner[1]
-execute store result score @s temp_store.arrow.uuid.2 run data get entity @s Owner[2]
-execute store result score @s temp_store.arrow.uuid.3 run data get entity @s Owner[3]
+execute store result score @s temp_store.uuid.0 run data get entity @s Owner[0]
+execute store result score @s temp_store.uuid.1 run data get entity @s Owner[1]
+execute store result score @s temp_store.uuid.2 run data get entity @s Owner[2]
+execute store result score @s temp_store.uuid.3 run data get entity @s Owner[3]
 
-
-
-
-tag @e[tag=arrow.checking] remove arrow.checking
+execute as @a run function tag:system/arrow/check_player

--- a/data/tag/functions/system/player/uuid.mcfunction
+++ b/data/tag/functions/system/player/uuid.mcfunction
@@ -1,0 +1,8 @@
+# LASERTAG player
+## get uuid
+
+
+execute store result score @s temp_store.uuid.0 run data get entity @s UUID[0]
+execute store result score @s temp_store.uuid.1 run data get entity @s UUID[1]
+execute store result score @s temp_store.uuid.2 run data get entity @s UUID[2]
+execute store result score @s temp_store.uuid.3 run data get entity @s UUID[3]

--- a/data/tag/functions/system/player/uuid.mcfunction
+++ b/data/tag/functions/system/player/uuid.mcfunction
@@ -6,3 +6,5 @@ execute store result score @s temp_store.uuid.0 run data get entity @s UUID[0]
 execute store result score @s temp_store.uuid.1 run data get entity @s UUID[1]
 execute store result score @s temp_store.uuid.2 run data get entity @s UUID[2]
 execute store result score @s temp_store.uuid.3 run data get entity @s UUID[3]
+
+tag @s add player.has_uuid


### PR DESCRIPTION
arrow's `Owner` tag is now matched with a real player's `UUID` to bind, this allows any number of customisation things to be possible for a player's arrow.

currently it copies an unused new tag `cosmetic.arrow_trail` to the arrow :3